### PR TITLE
add support for defaultOpen

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,12 @@
     <div id=popup4 popup=hint>Pop up</div>
     <div id=popup5 popup=manual>Pop up</div>
     <div id=popup6 popup=invalid>Invalid Pop up</div>
+
+    <div id=popup7 popup=hint defaultopen>Default Open Pop up</div>
+    <div id=popup8 popup=auto defaultopen>Not Default Open Pop up</div>
+    <div id=popup9 popup=auto defaultopen>Not Default Open Pop up</div>
+    <div id=popup10 popup=manual defaultopen>Default Open Pop up</div>
+    <div id=popup11 popup=manual defaultopen>Default Open Pop up</div>
   </div>
 
 </body>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -66,4 +66,21 @@ export function apply() {
     }
 
   })
+
+  function showDefaultOpen() {
+    // Only the first auto popup is shown. hint popups are not shown
+    const popup = document.querySelector('[popup=auto i][defaultopen]')
+    if (popup) popup.showPopUp()
+    // All manual popups are shown
+    for (const popup of document.querySelectorAll('[popup=manual i][defaultopen]')) {
+      popup.showPopUp()
+    }
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    showDefaultOpen()
+  } else {
+    document.addEventListener('DOMContentLoaded', showDefaultOpen, { once: true })
+  }
+
 }

--- a/tests/defaultopen.spec.ts
+++ b/tests/defaultopen.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/')
+})
+
+test('defaultopen should open on page load', async ({ page }) => {
+  const popup7 = (await page.locator('#popup7')).nth(0)
+  await expect(popup7).toBeHidden()
+  const popup8 = (await page.locator('#popup8')).nth(0)
+  await expect(popup8).toBeVisible()
+  const popup9 = (await page.locator('#popup9')).nth(0)
+  await expect(popup9).toBeHidden()
+  const popup10 = (await page.locator('#popup10')).nth(0)
+  await expect(popup10).toBeVisible()
+  const popup11 = (await page.locator('#popup11')).nth(0)
+  await expect(popup11).toBeVisible()
+})
+
+test('defaultOpen prop should true if attribute present', async ({ page }) => {
+  const popup7 = (await page.locator('#popup7')).nth(0)
+  await expect(await popup7.evaluate(node => node.defaultOpen)).toBe(true)
+
+  const popup8 = (await page.locator('#popup8')).nth(0)
+  await expect(await popup8.evaluate(node => node.defaultOpen)).toBe(true)
+
+  const popup9 = (await page.locator('#popup9')).nth(0)
+  await expect(await popup9.evaluate(node => node.defaultOpen)).toBe(true)
+
+  const popup10 = (await page.locator('#popup10')).nth(0)
+  await expect(await popup10.evaluate(node => node.defaultOpen)).toBe(true)
+
+  const popup11 = (await page.locator('#popup11')).nth(0)
+  await expect(await popup11.evaluate(node => node.defaultOpen)).toBe(true)
+})


### PR DESCRIPTION
## Description

Following from #1 this adds support for `defaultOpen`, which should open the first marked popup on page load.