### PR TITLE
use weakset for visible elements

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -10,7 +10,7 @@ const notSupportedMessage =
   'Not supported on element that does not have valid popup attribute';
 
 export function apply() {
-  const visibleElements = new Set<HTMLElement>();
+  const visibleElements = new WeakSet<HTMLElement>();
 
   Object.defineProperties(HTMLElement.prototype, {
     popUp: {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&memoryleak)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description

The current implementation uses a `Set` to track visible elements, but if these are _removed_ from the DOM before being hidden, then this will leak memory as it holds a hard reference. We can instead use a `WeakSet` which weakly holds references to the elements.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._
N/A


## Show me
_Provide screenshots/animated gifs/videos if necessary._
N/A

# REMEMBER: Attach this PR to the Trello card
