### PR TITLE
add click to dismiss behaviour

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -20,6 +20,17 @@
   inset-block-end: 0;
 }
 
+/* stylelint-disable selector-class-pattern */
+[popup='' i].\:open,
+[popup='auto' i].\:open,
+[popup='hint' i].\:open,
+[popup='manual' i].\:open {
+  display: block;
+  position: fixed;
+  z-index: 2147483647;
+}
+/* stylelint-enable selector-class-pattern */
+
 @media (prefers-color-scheme: dark) {
   [popup='' i],
   [popup='auto' i],

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -50,8 +50,7 @@ export function apply() {
             'Invalid on already-showing popups',
             'InvalidStateError',
           );
-        this.style.display = 'block';
-        this.style.position = 'fixed';
+        this.classList.add(':open');
         visibleElements.add(this);
         if (this.popUp === 'auto') {
           const focusEl = this.hasAttribute('autofocus')
@@ -73,7 +72,7 @@ export function apply() {
             'Invalid on already-hidden popups',
             'InvalidStateError',
           );
-        this.style.display = 'none';
+        this.classList.remove(':open');
         visibleElements.delete(this);
       },
     },
@@ -101,4 +100,19 @@ export function apply() {
       once: true,
     });
   }
+
+  document.addEventListener('click', (event: Event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const doc = target.ownerDocument;
+    const effectedPopup: HTMLElement | null = target.closest('[popup]');
+
+    // Dismiss open popups
+    for (const popup of doc.querySelectorAll(
+      '[popup="" i].\\:open, [popup=auto i].\\:open, [popup=hint i].\\:open',
+    )) {
+      if (popup instanceof HTMLElement && popup !== effectedPopup)
+        popup.hidePopUp();
+    }
+  });
 }

--- a/tests/dismiss.spec.ts
+++ b/tests/dismiss.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+});
+
+test('click dismisses all auto/hint popups', async ({ page }) => {
+  const popup7 = (await page.locator('#popup7')).nth(0);
+  await expect(popup7).toBeHidden();
+  const popup8 = (await page.locator('#popup8')).nth(0);
+  await expect(popup8).toBeVisible();
+  const popup9 = (await page.locator('#popup9')).nth(0);
+  await expect(popup9).toBeHidden();
+  const popup10 = (await page.locator('#popup10')).nth(0);
+  await expect(popup10).toBeVisible();
+  const popup11 = (await page.locator('#popup11')).nth(0);
+  await expect(popup11).toBeVisible();
+
+  await page.click('h1');
+  await expect(popup8).toBeHidden();
+  await expect(popup10).toBeVisible();
+  await expect(popup11).toBeVisible();
+});
+
+test('click inside manual popup dismisses other auto/hint popups', async ({
+  page,
+}) => {
+  const popup7 = (await page.locator('#popup7')).nth(0);
+  await expect(popup7).toBeHidden();
+  const popup8 = (await page.locator('#popup8')).nth(0);
+  await expect(popup8).toBeVisible();
+  const popup9 = (await page.locator('#popup9')).nth(0);
+  await expect(popup9).toBeHidden();
+  const popup10 = (await page.locator('#popup10')).nth(0);
+  await expect(popup10).toBeVisible();
+  const popup11 = (await page.locator('#popup11')).nth(0);
+  await expect(popup11).toBeVisible();
+
+  await page.click('#popup11');
+  await expect(popup8).toBeHidden();
+  await expect(popup10).toBeVisible();
+  await expect(popup11).toBeVisible();
+});
+
+test('click inside auto popup does not dismiss itself', async ({ page }) => {
+  const popup7 = (await page.locator('#popup7')).nth(0);
+  await expect(
+    await popup7.evaluate((node) => node.showPopUp()),
+  ).toBeUndefined();
+  const popup8 = (await page.locator('#popup8')).nth(0);
+  await expect(popup8).toBeVisible();
+
+  await popup8.evaluate((node) => node.click());
+  await expect(popup7).toBeHidden();
+  await expect(popup8).toBeVisible();
+});
+
+test('click inside hint popup does not dismiss itself', async ({ page }) => {
+  const popup7 = (await page.locator('#popup7')).nth(0);
+  await expect(
+    await popup7.evaluate((node) => node.showPopUp()),
+  ).toBeUndefined();
+  await expect(popup7).toBeVisible();
+  const popup8 = (await page.locator('#popup8')).nth(0);
+  await expect(popup8).toBeVisible();
+
+  await popup7.evaluate((node) => node.click());
+  await expect(popup7).toBeVisible();
+  await expect(popup8).toBeHidden();
+});


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&dismiss)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description

This adds the `:open` pseudo-pseudo-class (that is, it looks like a psuedo class but it's a regular class with an escaped `:`) which allows us to query-select for all open popups. This allows us to close all auto/hint popups on click, by using a queryselector. It also allows us to move some of the required CSS into the stylesheet, rather than through inline syles in JS.

I've also added tests to affirm the click dismiss behaviour.

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me
_Provide screenshots/animated gifs/videos if necessary._


# REMEMBER: Attach this PR to the Trello card
